### PR TITLE
将AI返回内容中的markdown代码块转换为普通json

### DIFF
--- a/src/services/bot/memory/index.ts
+++ b/src/services/bot/memory/index.ts
@@ -7,7 +7,9 @@ import { openai } from "../../openai";
 import { MessageContext } from "../conversation";
 import { LongTermMemoryAgent } from "./long-term";
 import { ShortTermMemoryAgent } from "./short-term";
+import {Logger} from "../../../utils/log";
 
+export const memoryLogger = Logger.create({ tag: "Memory" });
 export class MemoryManager {
   private room: Room;
 
@@ -118,6 +120,7 @@ export class MemoryManager {
       lastMemory,
     });
     if (!newMemory) {
+      memoryLogger.error("💀 生成短期记忆失败");
       return false;
     }
     const res = await ShortTermMemoryCRUD.addOrUpdate({
@@ -151,6 +154,7 @@ export class MemoryManager {
       lastMemory,
     });
     if (!newMemory) {
+      memoryLogger.error("💀 生成长期记忆失败");
       return false;
     }
     const res = await LongTermMemoryCRUD.addOrUpdate({

--- a/src/services/bot/memory/index.ts
+++ b/src/services/bot/memory/index.ts
@@ -100,7 +100,7 @@ export class MemoryManager {
       threshold?: number;
     }
   ) {
-    const { threshold = 1 } = options;
+    const { threshold = 10 } = options;
     const lastMemory = firstOf(await this.getShortTermMemories({ take: 1 }));
     const newMemories: (Memory & {
       msg: Message & {

--- a/src/services/bot/memory/long-term.ts
+++ b/src/services/bot/memory/long-term.ts
@@ -1,6 +1,7 @@
 import { LongTermMemory, ShortTermMemory } from "@prisma/client";
-import { jsonDecode, lastOf } from "../../../utils/base";
+import { lastOf } from "../../../utils/base";
 import { buildPrompt } from "../../../utils/string";
+import { cleanJsonAndDecode } from "../../../utils/parse";
 import { openai } from "../../openai";
 import { MessageContext } from "../conversation";
 
@@ -67,10 +68,6 @@ export class LongTermMemoryAgent {
         shortTermMemory: lastOf(newMemories)!.text,
       }),
     });
-    // 如果返回内容是个markdown代码块,就让他变回普通json
-    res?.content?.trim();
-    if (res?.content?.startsWith("```json")) {res.content = res?.content?.replace("```json", "");}
-    if (res?.content?.endsWith("```")) {res.content = res?.content?.replace("```", "");}
-    return jsonDecode(res?.content)?.longTermMemories?.toString();
+    return cleanJsonAndDecode(res?.content)?.longTermMemories?.toString();
   }
 }

--- a/src/services/bot/memory/long-term.ts
+++ b/src/services/bot/memory/long-term.ts
@@ -67,6 +67,10 @@ export class LongTermMemoryAgent {
         shortTermMemory: lastOf(newMemories)!.text,
       }),
     });
+    // 如果返回内容是个markdown代码块,就让他变回普通json
+    res?.content?.trim();
+    if (res?.content?.startsWith("```json")) {res.content = res?.content?.replace("```json", "");}
+    if (res?.content?.endsWith("```")) {res.content = res?.content?.replace("```", "");}
     return jsonDecode(res?.content)?.longTermMemories?.toString();
   }
 }

--- a/src/services/bot/memory/short-term.ts
+++ b/src/services/bot/memory/short-term.ts
@@ -78,6 +78,10 @@ export class ShortTermMemoryAgent {
           .join("\n"),
       }),
     });
+    // 如果返回内容是个markdown代码块,就让他变回普通json
+    res?.content?.trim();
+    if (res?.content?.startsWith("```json")) {res.content = res?.content?.replace("```json", "");}
+    if (res?.content?.endsWith("```")) {res.content = res?.content?.replace("```", "");}
     return jsonDecode(res?.content)?.shortTermMemories?.toString();
   }
 }

--- a/src/services/bot/memory/short-term.ts
+++ b/src/services/bot/memory/short-term.ts
@@ -1,5 +1,5 @@
 import { Memory, Message, ShortTermMemory, User } from "@prisma/client";
-import { jsonDecode } from "../../../utils/base";
+import { cleanJsonAndDecode } from "../../../utils/parse";
 import { buildPrompt, formatMsg } from "../../../utils/string";
 import { openai } from "../../openai";
 import { MessageContext } from "../conversation";
@@ -78,10 +78,6 @@ export class ShortTermMemoryAgent {
           .join("\n"),
       }),
     });
-    // 如果返回内容是个markdown代码块,就让他变回普通json
-    res?.content?.trim();
-    if (res?.content?.startsWith("```json")) {res.content = res?.content?.replace("```json", "");}
-    if (res?.content?.endsWith("```")) {res.content = res?.content?.replace("```", "");}
-    return jsonDecode(res?.content)?.shortTermMemories?.toString();
+    return cleanJsonAndDecode(res?.content)?.shortTermMemories?.toString();
   }
 }

--- a/src/services/speaker/base.ts
+++ b/src/services/speaker/base.ts
@@ -5,7 +5,8 @@ import {
   getMiIOT,
   getMiNA,
 } from "mi-service-lite";
-import { clamp, jsonEncode, sleep } from "../../utils/base";
+import { clamp, sleep } from "../../utils/base";
+import { jsonEncode } from "../../utils/parse";
 import { Logger } from "../../utils/log";
 import { StreamResponse } from "./stream";
 import { kAreYouOK } from "../../utils/string";

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -1,4 +1,5 @@
 import { isEmpty } from "./is";
+import { jsonEncode } from "./parse"
 
 export function timestamp() {
   return new Date().getTime();
@@ -85,24 +86,6 @@ export function toSet<T = any>(datas: T[], byKey?: (e: T) => any) {
     return newDatas;
   }
   return Array.from(new Set(datas));
-}
-
-export function jsonEncode(obj: any, options?: { prettier?: boolean }) {
-  const { prettier } = options ?? {};
-  try {
-    return prettier ? JSON.stringify(obj, undefined, 4) : JSON.stringify(obj);
-  } catch (error) {
-    return undefined;
-  }
-}
-
-export function jsonDecode(json: string | null | undefined) {
-  if (json == undefined) return undefined;
-  try {
-    return JSON.parse(json!);
-  } catch (error) {
-    return undefined;
-  }
 }
 
 export function withDefault<T = any>(e: any, defaultValue: T): T {

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -1,7 +1,7 @@
 import fs from "fs-extra";
 import path from "path";
 
-import { jsonDecode, jsonEncode } from "./base";
+import { jsonDecode, jsonEncode } from "./parse";
 
 export const kRoot = process.cwd();
 

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,0 +1,32 @@
+/**
+ * 清理掉json字符串前后的其他字符,并解码
+ */
+export function cleanJsonAndDecode(input: string | undefined | null) {
+  if (input == undefined) return undefined;
+  const pattern = /(\{[\s\S]*?"\s*:\s*[\s\S]*?})/;
+  const match = input.match(pattern);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return jsonDecode(match[0]);
+}
+
+export function jsonEncode(obj: any, options?: { prettier?: boolean }) {
+  const { prettier } = options ?? {};
+  try {
+    return prettier ? JSON.stringify(obj, undefined, 4) : JSON.stringify(obj);
+  } catch (error) {
+    return undefined;
+  }
+}
+
+export function jsonDecode(json: string | null | undefined) {
+  if (json == undefined) return undefined;
+  try {
+    return JSON.parse(json!);
+  } catch (error) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
在生成记忆时,部分LLM有概率返回markdown代码块格式而非单纯地json格式,导致无法解析并创建记忆.

这个pr尝试移除掉代码块标记,并在生成记忆错误时打印log