### PR TITLE
增加安装依赖后需要执行构建依赖命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@
 ```shell
 pnpm install
 ```
+安装依赖时候出现Warning:
+
+```
+╭ Warning-───────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                            │
+│   Ignored build scripts: @prisma/client, @prisma/engines, esbuild, mi-gpt, prisma.         │
+│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
+│                                                                                            │
+╰────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+请按照提示执行命令构建依赖：
+```
+pnpm approve-builds
+```
 
 然后，创建并启动 `MiGPT` 实例，查看如何[「配置参数」](https://github.com/idootop/mi-gpt/tree/main#%EF%B8%8F-%E9%85%8D%E7%BD%AE%E5%8F%82%E6%95%B0)。
 


### PR DESCRIPTION
在执行`pnpm install`后，如果不对依赖进行重新构建，执行执行`pnpm run start`会报错，如下：
```
file:///D:/07_code/nodejs/mi-gpt/node_modules/.pnpm/mi-gpt@4.2.0/node_modules/mi-gpt/dist/index.js:5
import { PrismaClient } from '@prisma/client';
         ^^^^^^^^^^^^
SyntaxError: The requested module '@prisma/client' does not provide an export named 'PrismaClient'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:146:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:229:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:473:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)

Node.js v20.17.0
 ELIFECYCLE  Command failed with exit code 1.
```